### PR TITLE
feat: added deep print function which allows to print objects for specified nested levels

### DIFF
--- a/src/components/ObjectUtils.brs
+++ b/src/components/ObjectUtils.brs
@@ -84,5 +84,64 @@ function ObjectUtils() as Object
     return picked
   end function
 
+  ' Deep print the nested object till specified level
+  ' @example
+  ' obj = {
+  '   "key11": "value11",
+  '   "key12": {
+  '     "key21": "value21",
+  '     "key22": {
+  '       "key31": "value31",
+  '     },
+  '   },
+  ' }
+  ' ObjectUtils().print(obj, 2)
+  ' prints
+  ' {
+  '   key11 : value11,
+  '   key12 {
+  '     key21 : value21,
+  '     key22 { object },
+  '   },
+  ' }
+  ' @param {Object} obj
+  ' @param {Integer} nestedUntil [default value is 3] - Object nesting level till it should be printed
+  prototype.print = function (obj as object, nestedUntil = 3 as integer)
+    if (nestedUntil < 1)
+      print "{ object }" 
+      return true
+    end if
+    
+    print "{"
+    m._printNestedObject(obj, nestedUntil)
+    print "}"
+  end function
+
+  ' @private
+  prototype._printNestedObject = function (obj as Object, nestedUntil as Integer, currentLevel = 1 as Integer)
+    indentationValue = 2
+    tabValue = currentLevel * indentationValue
+
+    for each property in obj.items()
+      if (getType(property.value) = "roAssociativeArray" OR getType(property.value) = "roSGNode")
+        if (currentLevel < nestedUntil)
+          m._printFormattedString(tabValue, Substitute("{0} {", property.key))
+          m._printNestedObject(property.value, nestedUntil, currentLevel + 1)
+        else
+          m._printFormattedString(tabValue, Substitute("{0} { object },", property.key))
+        end if
+      else
+        m._printFormattedString(tabValue, Substitute("{0} : {1},", property.key, property.value.toStr()))
+      end if
+    end for
+
+    if (currentLevel > 1) then m._printFormattedString((tabValue - indentationValue), "},")
+  end function
+
+  ' @private
+  prototype._printFormattedString = function (tabValue as Integer, str as String)
+    print Tab(tabValue) str
+  end function
+
   return prototype
 end function

--- a/src/components/ObjectUtils.brs
+++ b/src/components/ObjectUtils.brs
@@ -95,7 +95,7 @@ function ObjectUtils() as Object
   '     },
   '   },
   ' }
-  ' ObjectUtils().print(obj, 2)
+  ' ObjectUtils().deepPrint(obj, 2)
   ' prints
   ' {
   '   key11 : value11,
@@ -106,12 +106,12 @@ function ObjectUtils() as Object
   ' }
   ' @param {Object} obj
   ' @param {Integer} nestedUntil [default value is 3] - Object nesting level till it should be printed
-  prototype.print = function (obj as object, nestedUntil = 3 as integer)
+  prototype.deepPrint = function (obj as object, nestedUntil = 3 as integer)
     if (nestedUntil < 1)
       print "{ object }" 
       return true
     end if
-    
+
     print "{"
     m._printNestedObject(obj, nestedUntil)
     print "}"


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-utils/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #ROKU-1310

Deep print function for the objects which prints nested objects till the specified nesting levels

## How did you implement it:

It is a recursive function which calles itself until the specified nesting levels and print the object properties for each level.

## How can we verify it:

<img width="647" alt="Screenshot 2022-06-13 at 12 20 00" src="https://user-images.githubusercontent.com/104912043/173333871-13ad784a-eef1-4217-a375-0c5ee3ca8141.png">
<img width="589" alt="Screenshot 2022-06-13 at 12 17 37" src="https://user-images.githubusercontent.com/104912043/173333867-d9c9937d-3d8e-4fda-92f8-39f0f88358f6.png">

## Todos:

- [ ] Write documentation (if required)
- [ ] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
