### PR TITLE
fix: [ROKU-1647] Animation does not work when called in the callback

### DIFF
--- a/src/components/animator/_tests/AnimatorCore_animate.test.brs
+++ b/src/components/animator/_tests/AnimatorCore_animate.test.brs
@@ -26,7 +26,7 @@ function TestSuite__AnimatorCore_animate()
     return ts.assertEqual(actual, expected, "The animation did not start")
   end function)
 
-  ts.addTest("it stops pending animation when trying to create the same one", function (ts as Object) as String
+  ts.addTest("it finishes pending animation when trying to create the same one", function (ts as Object) as String
     ' Given
     element = CreateObject("roSGNode", "Node")
     element.id = "testElement"
@@ -39,7 +39,7 @@ function TestSuite__AnimatorCore_animate()
     m.__animator.animate(element, { field: "animatedField", keyValue: [0, 1], duration: 5 })
 
     ' Then
-    return ts.assertEqual(firstAnimation.control, "stop")
+    return ts.assertEqual(firstAnimation.control, "finish")
   end function)
 
   return ts

--- a/src/components/animator/_tests/AnimatorCore_promise.test.brs
+++ b/src/components/animator/_tests/AnimatorCore_promise.test.brs
@@ -12,7 +12,7 @@ function TestSuite__AnimatorCore_promise()
     end sub)
 
     ' Then
-    return ts.assertEqual(m.__animateRejectionReason, "Wrong parameter")
+    return ts.assertEqual(m.__animateRejectionReason, "Wrong animate parameter")
   end function)
 
   ts.addTest("it returns a rejected promise if not passed keyValue option", function (ts as Object) as String
@@ -28,7 +28,7 @@ function TestSuite__AnimatorCore_promise()
     end sub)
 
     ' Then
-    return ts.assertEqual(m.__animateRejectionReason, "Wrong parameter")
+    return ts.assertEqual(m.__animateRejectionReason, "Wrong animate parameter")
   end function)
 
   ts.addTest("it resolves promise when animation is done", function (ts as Object) as String


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/getndazn/kopytko-utils/issues/19

The behavior of the `animate` function should now be handled properly and it should be possible to call new animations when the previous one was resolved or rejected.

However, I don't fully understand why aborted animation is rejected and handled like an error, but I didn't change this behavior to not break anything in case of someone already handling it this way and to not introduce a breaking change.

## How did you implement it:

`AnimatorCore.animate` before clearing up the previous animation context checks if the previous promise was resolved.
If yes, then it queues the next animation instead of replacing the old one.

## How can we verify it:

Given there is a component with an **id** _container_ the following code:

```brs
    m.container.opacity = 1.0

    ' Immediate calls
    Animator().fadeOut(m.container, { duration: 2 }).finally(sub (state as String)
      ?"Faded Out - ";state
    end sub)
    Animator().fadeIn(m.container, { duration: 2 }).finally(sub (state as String)
      ?"Faded In - ";state
    end sub)
    Animator().fadeOut(m.container, { duration: 2 }).finally(sub (state as String, m as Object)
      ?"Again Faded Out - ";state
      ' Callback calls
      Animator().fadeIn(m.container, { duration: 2 }).finally(sub (state as String, m as Object)
        ?"Again Faded In - ";state
        Animator().fadeOut(m.container, { duration: 2 }).finally(sub (state as String, m as Object)
          ?"And Again Faded Out - ";state
          Animator().fadeIn(m.container, { duration: 2 }).finally(sub (state as String)
            ?"And Again Faded In - ";state
          end sub)
        end sub, m)
      end sub, m)
    end sub, m)
```

should log the following steps:

```bash
Faded Out - aborted
Faded In - aborted
Again Faded Out - stopped
Again Faded In - stopped
And Again Faded Out - stopped
And Again Faded In - stopped
```

And all animations should behave accordingly, so **2 first will be aborted, and the next 4 should proceed in proper order**.

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
