### PR TITLE
fix: Returning case-insensitive data in CacheFS

### DIFF
--- a/src/components/CacheFS.brs
+++ b/src/components/CacheFS.brs
@@ -1,4 +1,6 @@
 ' @import /components/rokuComponents/EVPDigest.brs
+
+' WARNING: the service must be used on the Task threads.
 function CacheFS() as Object
   prototype = {}
 
@@ -26,7 +28,7 @@ function CacheFS() as Object
 
     content = ReadAsciiFile(filePath)
 
-    return ParseJson(content)
+    return ParseJson(content, "i")
   end function
 
   ' Writes data into cachefs under the specific key


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-utils/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

ParseJSON by default returns case-sensitive AA which usually is not intended.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
