### PR TITLE
fix: Handling non-string parameters by buildUrl

### DIFF
--- a/src/components/CacheFS.brs
+++ b/src/components/CacheFS.brs
@@ -59,18 +59,18 @@ function CacheFS(folder = "kopytkoCache" as String) as Object
 
   ' Clears all data from cachefs under the specific directory
   ' @returns {Boolean} true if all directory data is successfully removed
-  prototype.clear = sub () as Boolean
+  prototype.clear = function () as Boolean
     if (m._fileSystem.delete(m._PREFIX + m._folder))
       return m._createFolder()
     end if
 
     return false
-  end sub
+  end function
 
   ' @private
-  prototype._createFolder = sub () as Boolean
+  prototype._createFolder = function () as Boolean
     return m._fileSystem.createDirectory(m._PREFIX + m._folder)
-  end sub
+  end function
 
   ' @private
   prototype._hash = function (text as String) as String

--- a/src/components/_tests/buildUrl.test.brs
+++ b/src/components/_tests/buildUrl.test.brs
@@ -42,18 +42,14 @@ function TestSuite__buildUrl() as Object
   ts.addTest("returns the proper URL for multiple params", function (ts as Object) as String
     ' Given
     path = "/example-path"
-    params = { paramOne: "valueOne", paramTwo: "valueTwo" }
-    ' Because "for each" loop for AAs doesn't guarantee the order, the result may be one of the following
-    expectedUrls = [
-      "/example-path?paramone=valueOne&paramtwo=valueTwo",
-      "/example-path?paramtwo=valueTwo&paramone=valueOne",
-    ]
+    params = { paramOne: "valueOne", paramTwo: 2, paramThree: false }
+    expectedUrl = "/example-path?paramone=valueOne&paramthree=false&paramtwo=2"
 
     ' When
     result = buildUrl(path, params)
 
     ' Then
-    return ts.assertArrayContains(expectedUrls, result)
+    return ts.assertEqual(result, expectedUrl)
   end function)
 
   ts.addTest("returns URL with encoded space sign", function (ts as Object) as String
@@ -82,10 +78,10 @@ function TestSuite__buildUrl() as Object
     return ts.assertEqual(result, expectedUrl)
   end function)
 
-  ts.addTest("ignores empty string parameter", function (ts as Object) as String
+  ts.addTest("ignores parameters that can't be converted to non-empty string", function (ts as Object) as String
     ' Given
     path = "/example-path"
-    params = { parameter: "" }
+    params = { param1: "", param2: ["p2"], param3: { p3: "p3"}, param4: invalid }
     expectedUrl = "/example-path"
 
     ' When

--- a/src/components/_tests/buildUrl.test.brs
+++ b/src/components/_tests/buildUrl.test.brs
@@ -81,7 +81,7 @@ function TestSuite__buildUrl() as Object
   ts.addTest("ignores parameters that can't be converted to non-empty string", function (ts as Object) as String
     ' Given
     path = "/example-path"
-    params = { param1: "", param2: ["p2"], param3: { p3: "p3"}, param4: invalid }
+    params = { param1: "", param2: ["p2"], param3: { p3: "p3"}, param4: CreateObject("roSGNode", "Node"), param5: invalid }
     expectedUrl = "/example-path"
 
     ' When

--- a/src/components/buildUrl.brs
+++ b/src/components/buildUrl.brs
@@ -3,7 +3,7 @@
 ' ?buildUrl("http://myurl.com", { queryString: "123" })
 ' ' prints http://myurl.com?queryString=123
 ' @param {String} path
-' @param {Object} [params=Invalid] - The AA of strings.
+' @param {Object} [params=Invalid] - The AA of values convertible to string.
 ' @returns {String}
 function buildUrl(path as String, params = Invalid as Object) as String
   ' It might be encoded already. To avoid encoding encoded url it needs to be decoded first.
@@ -14,10 +14,18 @@ function buildUrl(path as String, params = Invalid as Object) as String
   end if
 
   paramParts = []
-  for each paramKey in params
-    value = params[paramKey]
+  for each paramKey in params.keys()
+    rawValue = params[paramKey]
+    value = Invalid
+
+    if (rawValue <> Invalid AND GetInterface(rawValue, "ifToStr") <> Invalid)
+      value = rawValue.toStr()
+    end if
+
     if (value <> Invalid AND value <> "")
       paramParts.push(paramKey.encodeUriComponent() + "=" + value.encodeUriComponent())
+    else
+      ?"buildUrl: '";paramKey;"' param is ignored because it can't be converted to string"
     end if
   end for
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-utils/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Currently, passing a non-string parameter crashes the app.
Changed `buildUrl` function to accept non-string parameters that can be converted to a string, e.g. boolean, int, etc.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Checking if the parameter implements `ifToStr` interface. If it does, then the value is converted and used, otherwise a warning is printed in the telnet
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
