### PR TITLE
fix: Fixed clearing context in Animator

### DIFF
--- a/src/components/animator/AnimatorCore.brs
+++ b/src/components/animator/AnimatorCore.brs
@@ -135,6 +135,8 @@ sub AnimatorCore_onAnimationStateChanged(event as Object)
   if (state = "stopped")
     contextName = event.getNode()
 
+    if (NOT m["$$animatorContexts"].doesExist(contextName)) then return
+
     context = m["$$animatorContexts"][contextName]
     m["$$animatorContexts"].delete(contextName)
     context.promise.resolve("stopped")


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-utils/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

It turned out that the root cause for not working animations triggered from the other animation's callback is clearing the context after the new animation is set up. Ie. calling `m["$$animatorContexts"][contextName].promise.resolve("stopped")` triggers the callback, which calls `Animator.animate`, which sets fields in the `m["$$animatorContexts"][contextName]`. After the execution of the callback is finished `m["$$animatorContexts"].delete(contextName)` is called which removes fields that were just set.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

The previous [fix](https://github.com/getndazn/kopytko-utils/pull/20) is not needed anymore, hence I reverted it.
Instead of it, I changed the order of resolving the promise and deleting context from the `$$animatorContexts` object
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Given there is a component with an id container the following code:
```brightscript
    m.container.opacity = 1.0

    ' Immediate calls
    Animator().fadeOut(m.container, { duration: 2 }).finally(sub (state as String)
      ?"Faded Out - ";state
    end sub)
    Animator().fadeIn(m.container, { duration: 2 }).finally(sub (state as String)
      ?"Faded In - ";state
    end sub)
    Animator().fadeOut(m.container, { duration: 2 }).finally(sub (state as String, m as Object)
      ?"Again Faded Out - ";state
      ' Callback calls
      Animator().fadeIn(m.container, { duration: 2 }).finally(sub (state as String, m as Object)
        ?"Again Faded In - ";state
        Animator().fadeOut(m.container, { duration: 2 }).finally(sub (state as String, m as Object)
          ?"And Again Faded Out - ";state
          Animator().fadeIn(m.container, { duration: 2 }).finally(sub (state as String)
            ?"And Again Faded In - ";state
          end sub)
        end sub, m)
      end sub, m)
    end sub, m)
```
<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
