### PR TITLE
feat: added support to color field interpolator to AnimatorFactory

### DIFF
--- a/src/components/animator/AnimatorFactory.brs
+++ b/src/components/animator/AnimatorFactory.brs
@@ -1,5 +1,6 @@
 ' @import /components/getProperty.brs
 ' @import /components/rokuComponents/Animation.brs
+' @import /components/rokuComponents/ColorFieldInterpolator.brs
 ' @import /components/rokuComponents/FloatFieldInterpolator.brs
 ' @import /components/rokuComponents/Vector2DFieldInterpolator.brs
 
@@ -65,6 +66,8 @@ function AnimatorFactory() as Object
       interpolator = FloatFieldInterpolator()
     else if (fieldOptions.type = "vector2d")
       interpolator = Vector2DFieldInterpolator()
+    else if (fieldOptions.type = "color")
+      interpolator = ColorFieldInterpolator()
     else
       print "Field ";fieldOptions.field;" cannot be animated. Unsupported type of a field."
 

--- a/src/components/animator/_tests/AnimatorFactory.test.brs
+++ b/src/components/animator/_tests/AnimatorFactory.test.brs
@@ -1,5 +1,6 @@
 ' @import /components/KopytkoTestSuite.brs from @dazn/kopytko-unit-testing-framework
 ' @mock /components/rokuComponents/Animation.brs
+' @mock /components/rokuComponents/ColorFieldInterpolator.brs
 ' @mock /components/rokuComponents/FloatFieldInterpolator.brs
 ' @mock /components/rokuComponents/Vector2DFieldInterpolator.brs
 function TestSuite__AnimatorFactory() as Object
@@ -85,6 +86,7 @@ function TestSuite__AnimatorFactory() as Object
   end function)
 
   ts.addParameterizedTests([
+    { field: "color", key: [0.0, 1.0], keyValue: ["#000000", "#FFFFFF"], type: "color" },
     { field: "opacity", key: [0.0, 1.0], keyValue: [0.0, 1.0], type: "float" },
     { field: "translation", key: [0.0, 1.0], keyValue: [[0.0, 200.0], [400.0, 1200.0]], type: "vector2d" },
   ], "it appends supported ${type} interpolator", function (ts as Object, params as Object) as String
@@ -116,13 +118,19 @@ function TestSuite__AnimatorFactory() as Object
     return ts.assertEqual(constructedInterpolatorFields, expectedInterpolatorFields, "The interpolator has no expected config")
   end function)
 
-  ts.addTest("it creates two interpolators", function (ts as Object) as String
+  ts.addTest("it creates three interpolators", function (ts as Object) as String
     ' Given
     options = {
       delay: Csng(0.2),
       duration: Csng(20),
       easeFunction: "linear",
       fields: [
+        {
+          field: "color",
+          key: [0.0, 1.0],
+          keyValue: ["#000000", "#FFFFFF"],
+          type: "color",
+        },
         {
           field: "opacity",
           key: [0.0, 1.0],
@@ -142,7 +150,7 @@ function TestSuite__AnimatorFactory() as Object
 
     ' Then
 
-    return ts.assertEqual(2, _animation.getChildCount(), "There is no two interpolators")
+    return ts.assertEqual(3, _animation.getChildCount(), "There is no three interpolators")
   end function)
 
   return ts

--- a/src/components/rokuComponents/ColorFieldInterpolator.brs
+++ b/src/components/rokuComponents/ColorFieldInterpolator.brs
@@ -1,0 +1,5 @@
+' Wrapper function for creating native ColorFieldInterpolator component.
+' @class
+function ColorFieldInterpolator() as Object
+  return CreateObject("roSGNode", "ColorFieldInterpolator")
+end function

--- a/src/components/rokuComponents/_mocks/ColorFieldInterpolator.mock.brs
+++ b/src/components/rokuComponents/_mocks/ColorFieldInterpolator.mock.brs
@@ -1,0 +1,17 @@
+' @import /components/_mocks/Mock.brs from @dazn/kopytko-unit-testing-framework
+
+' @returns {Mock}
+function ColorFieldInterpolator() as Object
+  return Mock({
+    testComponent: m,
+    name: "ColorFieldInterpolator",
+    fields: {
+      fieldToInterp: "",
+      key: [],
+      keyValue: [],
+      fraction: 0.0,
+      reverse: false,
+      __subtype: "ColorFieldInterpolator",
+    },
+  })
+end function


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-utils/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added support to color field interpolator to AnimatorFactory.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added `ColorFieldInterpolator` and used it when `fieldOptions.type` is equal `color` in `AnimatorFactory`
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write documentation (if required)
- [X] Fix linting errors
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
