### PR TITLE
feat: params could be an array of key, value objects to preserve order

### DIFF
--- a/src/components/_tests/buildUrl.test.brs
+++ b/src/components/_tests/buildUrl.test.brs
@@ -91,5 +91,69 @@ function TestSuite__buildUrl() as Object
     return ts.assertEqual(result, expectedUrl)
   end function)
 
+  ts.addTest("returns path if params is an empty array", function (ts as Object) as String
+    ' Given
+    path = "/example-path"
+    params = []
+
+    ' When
+    result = buildUrl(path, params)
+
+    ' Then
+    return ts.assertEqual(result, path)
+  end function)
+
+  ts.addTest("returns the proper URL for single param as array", function (ts as Object) as String
+    ' Given
+    path = "/example-path"
+    params = [{ key: "parameter", value: "valueOne" }]
+    expectedUrl = "/example-path?parameter=valueOne"
+
+    ' When
+    result = buildUrl(path, params)
+
+    ' Then
+    return ts.assertEqual(result, expectedUrl)
+  end function)
+
+  ts.addTest("returns the proper URL for multiple params as array preserving order", function (ts as Object) as String
+    ' Given
+    path = "/example-path"
+    params = [{ key: "paramOne", value: "valueOne" }, { key: "paramTwo", value: 2 }, { key: "paramThree", value: false }]
+    expectedUrl = "/example-path?paramOne=valueOne&paramTwo=2&paramThree=false"
+
+    ' When
+    result = buildUrl(path, params)
+
+    ' Then
+    return ts.assertEqual(result, expectedUrl)
+  end function)
+
+  ts.addTest("returns URL with encoded space sign for array params", function (ts as Object) as String
+    ' Given
+    path = "http://roku.com/my test.html?john= doe"
+    params = [{ key: "parameter", value: "value One" }]
+    expectedUrl = "http://roku.com/my%20test.html?john=%20doe&parameter=value%20One"
+
+    ' When
+    result = buildUrl(path, params)
+
+    ' Then
+    return ts.assertEqual(result, expectedUrl)
+  end function)
+
+  ts.addTest("ignores array parameters that can't be converted to non-empty string", function (ts as Object) as String
+    ' Given
+    path = "/example-path"
+    params = [{ key: "param1", value: "" }, { key: "param2", value: invalid }]
+    expectedUrl = "/example-path"
+
+    ' When
+    result = buildUrl(path, params)
+
+    ' Then
+    return ts.assertEqual(result, expectedUrl)
+  end function)
+
   return ts
 end function

--- a/src/components/buildUrl.brs
+++ b/src/components/buildUrl.brs
@@ -1,3 +1,6 @@
+
+' @import /components/getType.brs
+
 ' Compose url with query strings. Values are encoded.
 ' @example
 ' ?buildUrl("http://myurl.com", { queryString: "123" })
@@ -14,20 +17,37 @@ function buildUrl(path as String, params = Invalid as Object) as String
   end if
 
   paramParts = []
-  for each paramKey in params.keys()
-    rawValue = params[paramKey]
-    value = Invalid
+  if (getType(params) = "roAssociativeArray")
+    for each paramKey in params.keys()
+      rawValue = params[paramKey]
+      value = Invalid
 
-    if (rawValue <> Invalid AND GetInterface(rawValue, "ifToStr") <> Invalid)
-      value = rawValue.toStr()
-    end if
+      if (rawValue <> Invalid AND GetInterface(rawValue, "ifToStr") <> Invalid)
+        value = rawValue.toStr()
+      end if
 
-    if (value <> Invalid AND value <> "")
-      paramParts.push(paramKey.encodeUriComponent() + "=" + value.encodeUriComponent())
-    else
-      ?"buildUrl: '";paramKey;"' param is ignored because it can't be converted to string"
-    end if
-  end for
+      if (value <> Invalid AND value <> "")
+        paramParts.push(paramKey.encodeUriComponent() + "=" + value.encodeUriComponent())
+      else
+        ?"buildUrl: '";paramKey;"' param is ignored because it can't be converted to string"
+      end if
+    end for
+  else if (getType(params) = "roArray")
+    for each param in params
+      rawValue = param.value
+      value = Invalid
+
+      if (rawValue <> Invalid AND GetInterface(rawValue, "ifToStr") <> Invalid)
+        value = rawValue.toStr()
+      end if
+
+      if (value <> Invalid AND value <> "")
+        paramParts.push(param.key.encodeUriComponent() + "=" + value.encodeUriComponent())
+      else
+        ?"buildUrl: '";param.key;"' param is ignored because it can't be converted to string"
+      end if
+    end for
+  end if
 
   if (paramParts.count() = 0)
     return encodedPath


### PR DESCRIPTION
The buildUrl function's params could be an array of objects, including 2 fields - key, value.
This functionality is for preserving the order of the query params if it is required to have them sorted in a particular way.